### PR TITLE
Fix cross-compilation for iOS and possibly other platforms

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -83,4 +83,7 @@ class PCREConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = tools.collect_libs(self)
+        if self.settings.os == "Windows" and self.settings.build_type == 'Debug':
+            self.cpp_info.libs = ['pcreposixd', 'pcred']
+        else:
+            self.cpp_info.libs = ['pcreposix', 'pcre']

--- a/conanfile.py
+++ b/conanfile.py
@@ -68,6 +68,8 @@ class PCREConan(ConanFile):
         cmake.definitions["PCRE_BUILD_PCRECPP"] = self.options.build_pcrecpp
         cmake.definitions["PCRE_SUPPORT_LIBZ"] = self.options.with_zlib
         cmake.definitions["PCRE_SUPPORT_LIBBZ2"] = self.options.with_bzip2
+        cmake.definitions["PCRE_SUPPORT_LIBREADLINE"] = False
+        cmake.definitions["PCRE_SUPPORT_LIBEDIT"] = False
         if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
             cmake.definitions["PCRE_STATIC_RUNTIME"] = not self.options.shared and "MT" in self.settings.compiler.runtime
         cmake.configure(build_folder=self.build_subfolder)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -18,12 +18,13 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with tools.environment_append(RunEnvironment(self).vars):
-            bin_path = os.path.join("bin", "test_package")
-            arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
-            if self.settings.os == "Windows":
-                self.run("%s %s" % (bin_path, arguments))
-            elif self.settings.os == "Macos":
-                self.run("DYLD_LIBRARY_PATH=%s %s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path, arguments))
-            else:
-                self.run("LD_LIBRARY_PATH=%s %s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path, arguments))
+        if not tools.cross_building(self.settings):
+            with tools.environment_append(RunEnvironment(self).vars):
+                bin_path = os.path.join("bin", "test_package")
+                arguments = "%sw+ Bincrafters" % ("\\" if self.settings.os == "Windows" else "\\\\")
+                if self.settings.os == "Windows":
+                    self.run("%s %s" % (bin_path, arguments))
+                elif self.settings.os == "Macos":
+                    self.run("DYLD_LIBRARY_PATH=%s %s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path, arguments))
+                else:
+                    self.run("LD_LIBRARY_PATH=%s %s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path, arguments))


### PR DESCRIPTION
Readline and edit libraries are referenced in the PCRE's cmake configuration but they're only used for tests and binaries which are not produced for the conan packages. As there's no check for that in the original cmake, if support for these libraries is not disabled an additional "-I /usr/include" gets added when cross-compiling for a platform that doesn't have those libraries available, such as iOS, since the system ones are found by CMake. This breaks compilation of the PCRE conan packages on those platforms.